### PR TITLE
added (static) tutorial to start screen

### DIFF
--- a/src/screens/game/ship.rs
+++ b/src/screens/game/ship.rs
@@ -75,7 +75,7 @@ impl Ship {
                 egui::pos2(draw_position.x + rx, draw_position.y + ry)
             })
             .collect();
-
+        
         // Draw the triangle
         ui.painter().add(egui::Shape::Path(egui::epaint::PathShape {
             points: rotated_points,

--- a/src/screens/start.rs
+++ b/src/screens/start.rs
@@ -26,6 +26,12 @@ impl Screen for Start {
             if ui.button("Exit :(").clicked() {
                 cmd = Some(ScreenCommand::ExitProgram);
             }
+            ui.label("controls:");
+            ui.label("forwards: w");
+            ui.label("turn left: a");
+            ui.label("turn right: d");
+            ui.label("reverse: s");
+            ui.label("shoot: space");
         });
 
         cmd

--- a/src/screens/start.rs
+++ b/src/screens/start.rs
@@ -27,10 +27,10 @@ impl Screen for Start {
                 cmd = Some(ScreenCommand::ExitProgram);
             }
             ui.label("controls");
-            ui.label("forwards   | w");
-            ui.label("turn left  | a");
-            ui.label("turn right | d");
-            ui.label("shoot      | space");
+            ui.label("forwards: w");
+            ui.label("turn left: a");
+            ui.label("turn right: d");
+            ui.label("shoot: space");
         });
 
         cmd

--- a/src/screens/start.rs
+++ b/src/screens/start.rs
@@ -26,12 +26,11 @@ impl Screen for Start {
             if ui.button("Exit :(").clicked() {
                 cmd = Some(ScreenCommand::ExitProgram);
             }
-            ui.label("controls:");
-            ui.label("forwards: w");
-            ui.label("turn left: a");
-            ui.label("turn right: d");
-            ui.label("reverse: s");
-            ui.label("shoot: space");
+            ui.label("controls");
+            ui.label("forwards   | w");
+            ui.label("turn left  | a");
+            ui.label("turn right | d");
+            ui.label("shoot      | space");
         });
 
         cmd


### PR DESCRIPTION
here's a placeholder Tutorial for your start screen.
This is just implemented using static strings in labels. 
If the controls can be remapped at a later stage this should be refactored to pull from the settings